### PR TITLE
Add support for monkey patching the Audi account region.

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -6,7 +6,7 @@ import asyncio
 
 import voluptuous as vol
 
-from audiapi.Services import RequestStatus
+from audiapi.Services import Service, RequestStatus
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (
@@ -102,6 +102,8 @@ CONFIG_SCHEMA = vol.Schema({
 
 async def async_setup(hass, config):
     """Set up the Audi Connect component."""
+    if config[DOMAIN].get(CONF_REGION):
+      Service.COUNTRY = config[DOMAIN].get(CONF_REGION)
 
     from .audi_connect_account import AudiConnectAccount
     connection = AudiConnectAccount(

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Configuration Variables
 
 **region**
 
-- (string)(Optional)The region where the Audi is registered. Needs to be set for users in North America or China.
+- (string)(Optional)The region where the Audi account is registered. Set to 'DE' for Europe (or leave unset), set to 'US' for North America. May need to be set for China.
 
 **name**
 


### PR DESCRIPTION
Hack this integration to work for US-based Audi vehicles. May break configurations for people who erroneously set 'region' (which appears otherwise unused) to some random value, but can be fixed by simply removing/overriding the configuration variable. 

This has been tested on a single US-based Audi car. 