### PR TITLE
Various fixes

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -484,7 +484,7 @@ class AudiConnectVehicle:
     @property
     def engine_type2_supported(self):
         check = self.vehicle.state.get('engineTypeSecondEngine')
-        if check: 
+        if check and check != 'unsupported':
             return True
 
     @property
@@ -503,6 +503,8 @@ class AudiConnectVehicle:
     def remaining_charging_time(self):
         """Return remaining charging time"""
         if self.remaining_charging_time_supported:
+            if self.vehicle.state.get('remainingChargingTime') == 65535:
+                return 'N/A'
             return self.parseToFloat(self.vehicle.state.get('remainingChargingTime'))
 
     @property

--- a/custom_components/audiconnect/dashboard.py
+++ b/custom_components/audiconnect/dashboard.py
@@ -237,7 +237,7 @@ class Position(Instrument):
 class LastUpdate(Instrument):
     def __init__(self):
         super().__init__(
-            component="sensor", attr="last_update_time", name="Last Update", icon="mdi:time")
+            component="sensor", attr="last_update_time", name="Last Update", icon="mdi:update")
         self.unit = None
 
     @property
@@ -276,9 +276,9 @@ def create_instruments():
         Sensor(attr="sun_roof", name="Sun roof", icon="mdi:weather-sunny", unit=None),
         BinarySensor(attr="parking_light", name="Parking light", device_class="safety"),
         BinarySensor(attr="any_window_open", name="Windows", device_class="window"),
-        BinarySensor(attr="any_door_unlocked", name="Doors", device_class="lock"),
-        BinarySensor(attr="any_door_open", name="Doors", device_class="door"),
-        BinarySensor(attr="trunk_unlocked", name="Trunk", device_class="lock"),
+        BinarySensor(attr="any_door_unlocked", name="Door Lock", device_class="lock"),
+        BinarySensor(attr="any_door_open", name="Door", device_class="door"),
+        BinarySensor(attr="trunk_unlocked", name="Trunk Lock", device_class="lock"),
         BinarySensor(attr="trunk_open", name="Trunk", device_class="door"),
         BinarySensor(attr="hood_open", name="Hood", device_class="door")
     ]


### PR DESCRIPTION
Add check for unsupported second engine
Return N/A when charging time is not applicable (not charging)
Last update icon does not exist. Changed to mdi-update
Binary Sensor naming collision for trunk and doors (locks vs doors)