### PR TITLE
check if vin of vehicle is None when adding since order vehicles have no vin

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -120,17 +120,18 @@ class AudiConnectAccount:
             return False
 
     async def add_or_update_vehicle(self, vehicle, vinlist):
-        if vinlist is None or vehicle.vin.lower() in vinlist:
-            vupd = [x for x in self._vehicles if x.vin == vehicle.vin.lower()]
-            if len(vupd) > 0:
-                await vupd[0].update()
-            else:
-                try:
-                    audiVehicle = AudiConnectVehicle(self._audi_service, vehicle)
-                    await audiVehicle.update()
-                    self._vehicles.append(audiVehicle)
-                except Exception:
-                    pass
+        if vehicle.vin is not None:
+            if vinlist is None or vehicle.vin.lower() in vinlist:
+                vupd = [x for x in self._vehicles if x.vin == vehicle.vin.lower()]
+                if len(vupd) > 0:
+                    await vupd[0].update()
+                else:
+                    try:
+                        audiVehicle = AudiConnectVehicle(self._audi_service, vehicle)
+                        await audiVehicle.update()
+                        self._vehicles.append(audiVehicle)
+                    except Exception:
+                        pass
 
     async def refresh_vehicle_data(self, vin: str):
         if not self._loggedin:


### PR DESCRIPTION
When you have an order vehicle in your audi connect account, this vehicle has no valid vin. Therefore, checking whether the `vin` is `None` when adding a new vehicle is required to exclude order vehicles from being added. WIthout this fix, the integration fails on setup of the account (within HA). Using the test script, the application fails with an exception.
The propsed fix assures that if the vin is None (which should only occur for order vehicles where no actions can be performed anyway) the vehicle is not considered further.

Was tested using the test script as well as within HA directly.