### PR TITLE
Adapting to extra_state_attributes instead of device_state_attributes

### DIFF
--- a/custom_components/audiconnect/audi_entity.py
+++ b/custom_components/audiconnect/audi_entity.py
@@ -53,7 +53,7 @@ class AudiEntity(Entity):
         return True
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return dict(
             self._instrument.attributes,

--- a/custom_components/audiconnect/device_tracker.py
+++ b/custom_components/audiconnect/device_tracker.py
@@ -125,7 +125,7 @@ class AudiDeviceTracker(TrackerEntity):
         }
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return dict(
             self._instrument.attributes,


### PR DESCRIPTION
many log entries are shows for the different attributes and entities populated due to the deprication of device_state_attributes.

