### PR TITLE
Change charge mode to JSON. Add support for timer charging

### DIFF
--- a/custom_components/audiconnect/audi_account.py
+++ b/custom_components/audiconnect/audi_account.py
@@ -191,9 +191,11 @@ class AudiAccount(AudiConnectObserver):
         if action == "stop_climatisation":
             await self.connection.set_vehicle_climatisation(vin, False)
         if action == "start_charger":
-            await self.connection.set_battery_charger(vin, True)
+            await self.connection.set_battery_charger(vin, True, False)
+        if action == "start_timed_charger":
+            await self.connection.set_battery_charger(vin, True, True)
         if action == "stop_charger":
-            await self.connection.set_battery_charger(vin, False)
+            await self.connection.set_battery_charger(vin, False, False)
         if action == "start_preheater":
             await self.connection.set_vehicle_pre_heater(vin, True)
         if action == "stop_preheater":

--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -241,7 +241,7 @@ class AudiConnectAccount:
                 ),
             )
 
-    async def set_battery_charger(self, vin: str, activate: bool):
+    async def set_battery_charger(self, vin: str, activate: bool, timer: bool):
         if not self._loggedin:
             await self.login()
 
@@ -250,16 +250,18 @@ class AudiConnectAccount:
 
         try:
             _LOGGER.debug(
-                "Sending command to {action} charger to vehicle {vin}".format(
-                    action="start" if activate else "stop", vin=vin
+                "Sending command to {action}{timer} charger to vehicle {vin}".format(
+                    action="start" if activate else "stop", vin=vin,
+                    timer=" timed" if timer else ""
                 ),
             )
 
-            await self._audi_service.set_battery_charger(vin, activate)
+            await self._audi_service.set_battery_charger(vin, activate, timer)
 
             _LOGGER.debug(
-                "Successfully {action} charger of vehicle {vin}".format(
-                    action="started" if activate else "stopped", vin=vin
+                "Successfully {action}{timer} charger of vehicle {vin}".format(
+                    action="started" if activate else "stopped", vin=vin,
+                    timer=" timed" if timer else ""
                 ),
             )
 

--- a/custom_components/audiconnect/audi_services.py
+++ b/custom_components/audiconnect/audi_services.py
@@ -456,12 +456,16 @@ class AudiService:
             "requestStatusResponse.status",
         )
 
-    async def set_battery_charger(self, vin: str, start: bool):
-        data = '<?xml version="1.0" encoding= "UTF-8" ?><action><type>{action}</type></action>'.format(
-            action="start" if start else "stop"
-        )
+    async def set_battery_charger(self, vin: str, start: bool, timer: bool):
+        if start and timer:
+            data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "timerBasedCharging" } } }}'
+        elif start:
+            data = '{ "action": { "type": "selectChargingMode", "settings": { "chargeModeSelection": { "value": "immediateCharging" } } }}'
+        else:
+            data = '{ "action": { "type": "stop" }}'
+
         headers = self._get_vehicle_action_header(
-            "application/vnd.vwg.mbb.ChargerAction_v1_0_0+xml", None
+            "application/json", None
         )
         res = await self._api.request(
             "POST",

--- a/custom_components/audiconnect/services.yaml
+++ b/custom_components/audiconnect/services.yaml
@@ -22,5 +22,6 @@ execute_vehicle_action:
     action:
       description: >
         The action to be executed. Possible choices, depending on subscription options, include 'lock', 'unlock', 
-        'start_climatisation', 'stop_climatisation, 'start_preheater', 'stop_preheater, 'start_window_heating', 'stop_window_heating'
+        'start_climatisation', 'stop_climatisation, 'start_charger', 'start_timed_charger', 'stop_charger',
+        'start_preheater', 'stop_preheater, 'start_window_heating', 'stop_window_heating'
       example: lock

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ Executes a given action in the vehicle. The service takes a vin and an action as
 - start_climatisation
 - stop_climatisation
 - start_charger
+- start_timed_charger
 - stop_charger
 - start_preheater
 - stop_preheater


### PR DESCRIPTION
The XML based request was no longer working for my 2019 e-tron. Changed
the request to JSON.

Added a new "start_timed_charger" service call which switches the car
from "immediate" charging to "timer". The regular "start_charger" service is
able to switch from "timer" charging back to "immediate".

Note the "stop_charger" action does not work for my car - the request is
accepeted by the Audi server, queued for delivery to the car and
fetched, but the car appears to ignore the request and does not stop
charging.

Resolves #93

Signed-off-by: Matt Redfearn <matt.redfearn@gmail.com>