### PR TITLE
Updated readme to clarify country codes for US/Canada

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Configuration Variables
 
 **region**
 
-- (string)(Optional)The region where the Audi account is registered. Set to 'DE' for Europe (or leave unset), to 'US' for North America, or to 'CN' for China.
+- (string)(Optional)The region where the Audi account is registered. Set to 'DE' for Europe (or leave unset), 'US' for United States of America, 'CA' for Canada, or 'CN' for China.
 
 **scan_interval**
 


### PR DESCRIPTION
The current readme indicated that "US" should be the region code for all North American cars, however this does not work for Canadian users, so I updated the docs to include both US and CA as valid country codes.