### PR TITLE
Remove deprecated IMPERIAL_SYSTEM check and update to new syntax

### DIFF
--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -94,7 +94,7 @@ async def async_setup_entry(hass, config_entry):
     account = config_entry.data.get(CONF_USERNAME)
 
     unit_system = "metric"
-    if hass.config.units.name == CONF_UNIT_SYSTEM_IMPERIAL:
+    if hass.config.units is US_CUSTOMARY_SYSTEM:
         unit_system = "imperial"
 
     if account not in hass.data[DOMAIN]:

--- a/custom_components/audiconnect/__init__.py
+++ b/custom_components/audiconnect/__init__.py
@@ -10,9 +10,14 @@ from homeassistant.const import (
     CONF_PASSWORD,
     CONF_RESOURCES,
     CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-    CONF_UNIT_SYSTEM_METRIC,
-    CONF_UNIT_SYSTEM_IMPERIAL
+    CONF_USERNAME
+)
+
+from homeassistant.util.unit_system import (
+    _CONF_UNIT_SYSTEM_US_CUSTOMARY,
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
 )
 
 from .audi_account import AudiAccount


### PR DESCRIPTION
Performed update inline with https://developers.home-assistant.io/blog/2022/10/14/deprecate-unit-system/