### PR TITLE
Set logintime to 0

### DIFF
--- a/custom_components/audiconnect/audi_connect_account.py
+++ b/custom_components/audiconnect/audi_connect_account.py
@@ -46,7 +46,7 @@ class AudiConnectAccount:
         self._username = username
         self._password = password
         self._loggedin = False
-        self._logintime = time.time()
+        self._logintime = 0
 
         self._connect_retries = 3
         self._connect_delay = 10


### PR DESCRIPTION
Login time should be initialized as `0` instead of the current time to prevent the use of tokens that might have expired due to the logic behind fetching new tokens.

The issue lies in that upon startup of the module, [the elapsed time](https://github.com/woopstar/audi_connect_ha/blob/7e602375015f702b774206be3f1c286479b795d3/custom_components/audiconnect/audi_connect_account.py#L100) is `elapsed_sec = time.time() - self._logintime`, which means upon startup the token has yet not expired in the module, but it can actually be expired already.

Fixes #175 
