### PR TITLE
fix: Added integration type to manifest

### DIFF
--- a/custom_components/audiconnect/manifest.json
+++ b/custom_components/audiconnect/manifest.json
@@ -3,6 +3,7 @@
   "name": "Audi Connect",
   "config_flow": true,
   "documentation": "https://github.com/arjenvrh/audi_connect_ha",
+  "integration_type": "hub",
   "issue_tracker": "https://github.com/arjenvrh/audi_connect_ha/issues",
   "requirements": ["beautifulsoup4"],
   "dependencies": [],

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,4 @@
 {
     "name": "Audi connect",
-    "domains": ["sensor", "binary_sensor", "switch", "device_tracker", "lock"],
     "homeassistant": "0.110.0"
 }


### PR DESCRIPTION
Integration type is required by HA now. 

HACS.json shouldn't have domains.  This isn't a valid key as per: https://hacs.xyz/docs/publish/start/#hacsjson

These corrections are detected by #208 