### PR TITLE
Update device_tracker.py

### DIFF
--- a/custom_components/audiconnect/device_tracker.py
+++ b/custom_components/audiconnect/device_tracker.py
@@ -1,7 +1,7 @@
 """Support for tracking an Audi."""
 import logging
 
-from homeassistant.components.device_tracker import SOURCE_TYPE_GPS
+from homeassistant.components.device_tracker import SourceType.GPS
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
@@ -79,7 +79,7 @@ class AudiDeviceTracker(TrackerEntity):
     @property
     def source_type(self):
         """Return the source type, eg gps or router, of the device."""
-        return SOURCE_TYPE_GPS
+        return SourceType.GPS
 
     async def async_added_to_hass(self):
         """Register state update callback."""


### PR DESCRIPTION
Recent log entry from Home Assistant indicates that the audiconnect integration is using a deprecated constant, SOURCE_TYPE_GPS. This constant is scheduled to be removed in the Home Assistant Core 2025.1 release. The recommended action is to use SourceType.GPS instead.

See also #217 #222 #221